### PR TITLE
Set the comment syntax for cryptol-mode

### DIFF
--- a/cryptol-mode.el
+++ b/cryptol-mode.el
@@ -260,7 +260,11 @@
 
   ;; Indentation, no tabs
   (set (make-local-variable 'tab-width) cryptol-tab-width)
-  (setq indent-tabs-mode nil))
+  (setq indent-tabs-mode nil)
+
+  ;; Comment syntax for M-;
+  (set (make-local-variable 'comment-start) "//")
+  (set (make-local-variable 'comment-end) ""))
 (provide 'cryptol-mode)
 
 ;;; ------------------------------------


### PR DESCRIPTION
Setting the comment syntax allows M-; to do the right thing without prompting. 

Fixes #18.