### PR TITLE
Update Cryptol URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ writing cryptographic code. From the homepage:
 > of an implementation to a reference specification, at each stage of
 > the toolchain.
 
-[Cryptol]: http://corp.galois.com/cryptol/
+[Cryptol]: https://www.cryptol.net/
 
 # Installation
 


### PR DESCRIPTION
The old address 404s. This fixes it in the README, but not the repository description.