### PR TITLE
Update list of keywords to latest from Cryptol documentation

### DIFF
--- a/cryptol-mode.el
+++ b/cryptol-mode.el
@@ -135,9 +135,10 @@
 (defvar cryptol-type-regexp "\\<[[:upper:]]\\w*")
 
 (defvar cryptol-keywords-regexp
-  (regexp-opt '( "module" "property" "where" "include"
-                 "let" "if" "else" "then" "type" "private" "import"
-                 "as" ) 'words))
+  (regexp-opt '("else" "include" "property" "let" "newtype" "primitive"
+                "extern" "module" "then" "import" "infixl" "parameter"
+                "if" "newtype" "type" "as" "infixr" "constraint"
+                "private" "pragma" "where" "hiding" "infix") 'words))
 
 ;;; -- Syntax table and highlighting -------------------------------------------
 


### PR DESCRIPTION
It looks like the collection of Cryptol keywords has been expanded since the regexp was written. This PR replaces the keyword list with the one from:
https://github.com/GaloisInc/cryptol/blob/master/docs/Syntax.md#keywords-and-built-in-operators